### PR TITLE
Add index on created_at column

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "7.*",
+        "php": ">= 7.2",
         "ext-json": "*",
         "laravel/framework": "^7.2"
     },

--- a/database/migrations/2020_02_24_191413_mitm_create_mails_table.php
+++ b/database/migrations/2020_02_24_191413_mitm_create_mails_table.php
@@ -18,7 +18,9 @@ class MitmCreateMailsTable extends Migration
     {
         Schema::create(self::TABLE, function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->timestamps();
+            $table->timestamp('created_at')
+                ->useCurrent()
+                ->index();
 
             // Metadata
             $table->text('subject')->default('');

--- a/src/Models/StoredMail.php
+++ b/src/Models/StoredMail.php
@@ -29,6 +29,9 @@ use VanEyk\MITM\Storage\Implementations\Filesystem\FilesystemStorage;
  */
 class StoredMail extends Model
 {
+    // We only need created_at, which is set on the database side, so we have no
+    // need for it here.
+    public $timestamps = false;
     protected $table = DatabaseStorage::TABLE_PREFIX . '_mails';
     protected $guarded = [];
     protected $dateFormat = FilesystemStorage::TIMESTAMP_FORMAT;

--- a/tests/Cases/Storage/MailStorageTestCase.php
+++ b/tests/Cases/Storage/MailStorageTestCase.php
@@ -107,13 +107,18 @@ abstract class MailStorageTestCase extends MITMTestCase
     }
 
     /**
-     * @depends it_can_store_mails_without_throwing
-     * @depends it_can_retrieve_a_stored_mail
+
      * @test
      */
     public function it_can_delete_old_mails(): void
     {
-        $old = $this->storage->save(TestMails::emptySwift(), TestMails::emptyStoredMail());
+        // IMPORTANT: As we normally would generate the created_at-timestamp in
+        // the database, we need to set it here manually to simulate different
+        // points in time!
+
+        $old = $this->storage->save(TestMails::emptySwift(), TestMails::emptyStoredMail()->fill([
+            'created_at' => now(),
+        ]));
         $oldId = $this->storage->id($old);
 
         // Lets travel to the future, so the mail we just stored is now over
@@ -121,7 +126,9 @@ abstract class MailStorageTestCase extends MITMTestCase
         Carbon::setTestNow(Carbon::now()->addWeeks(2));
 
         // This newly stored mail should not be deleted!
-        $new = $this->storage->save(TestMails::emptySwift(), TestMails::emptyStoredMail());
+        $new = $this->storage->save(TestMails::emptySwift(), TestMails::emptyStoredMail()->fill([
+            'created_at' => now(),
+        ]));
         $newId = $this->storage->id($new);
 
         $lastWeek = Carbon::now()->subWeek()->toString();

--- a/tests/Cases/Storage/MailStorageTestCase.php
+++ b/tests/Cases/Storage/MailStorageTestCase.php
@@ -15,7 +15,7 @@ use VanEyk\MITM\Storage\MailStorage;
 abstract class MailStorageTestCase extends MITMTestCase
 {
     /** @var MailStorage */
-    private $storage;
+    protected $storage;
 
     abstract public function mitmConfig(): array;
 

--- a/tests/Suite/Storage/DatabaseStorageTest.php
+++ b/tests/Suite/Storage/DatabaseStorageTest.php
@@ -2,10 +2,11 @@
 
 namespace Test\Suite\Storage;
 
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Test\Cases\Storage\MailStorageTestCase;
-use VanEyk\MITM\Storage\Implementations\Database\DatabaseStorage;
-use VanEyk\MITM\Models\StoredMail;
 
 /**
  * @covers \VanEyk\MITM\Storage\Implementations\Database\DatabaseStorage
@@ -23,5 +24,33 @@ class DatabaseStorageTest extends MailStorageTestCase
     public function mitmConfig(): array
     {
         return ['storage_driver' => 'database'];
+    }
+
+    /**
+     * This test is not really implemented very robustly, as it only checks, if
+     * the query plan for pagination contains the substring 'USING INDEX'.
+     *
+     * Moreover this is highly specific to the testing sqlite, but other
+     * databases should hopefully also use the index if sqlite does.
+     *
+     * This test should act as a way of ensuring that the performance is fine.
+     *
+     * @test
+     */
+    public function it_uses_an_index_for_pagination()
+    {
+        DB::listen(function (QueryExecuted $execution) {
+            if (Str::contains(Str::lower($execution->sql), 'explain')) {
+                return;
+            }
+
+            $explanations = DB::select("EXPLAIN QUERY PLAN $execution->sql");
+            $this->assertCount(1, $explanations);
+
+            $detail = $explanations[0]->detail;
+            $this->assertStringContainsString('USING INDEX', $detail);
+        });
+
+        $this->storage->paginate();
     }
 }


### PR DESCRIPTION
This should speed up the performance when using the `database` storage. Now it should load quickly, even when you have lots of mails stored.